### PR TITLE
Web update: peq and player management

### DIFF
--- a/bin/players.py
+++ b/bin/players.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+
+""" A module that controls and retrieve track info from the current player
+"""
+import subprocess as sp
+import yaml
+import jack
+import mpd
+import time
+
+mpd_host    = 'localhost'
+mpd_port    = 6600
+mpd_passwd  = None
+
+def get_predic_state():
+    """ returns the YAML pre.di.c's status info """
+
+    f = open('/home/predic/config/state.yml', 'r')
+    tmp = f.read()
+    f.close()
+    return yaml.load(tmp)
+
+def mpd_client(query):
+    """ comuticates to MPD music player daemon """
+
+    def get_meta():
+        """ gets info from mpd """
+
+        player = 'MPD'
+        artist = album = title = ''
+
+        try:
+            # We try because not all tracks have complete metadata fields:
+            try:    artist = client.currentsong()['artist']
+            except: pass
+            try:    album  = client.currentsong()['album']
+            except: pass
+            try:    title  = client.currentsong()['title']
+            except: pass
+            client.close()
+        except:
+            pass
+
+        return '{ "player":"' + player + '", "artist":"' + artist + \
+               '", "album":"' + album + '", "title":"' + title + '" }'
+
+    def stop():
+        if mpd_online:
+            client.stop()
+            return client.status()['state']
+    def pause():
+        if mpd_online:
+            client.pause()
+            return client.status()['state']
+    def play():
+        if mpd_online:
+            client.play()
+            return client.status()['state']
+    def next():
+        if mpd_online:
+            client.next()
+            return client.status()['state']
+    def previous():
+        if mpd_online:
+            client.previous()
+            return client.status()['state']
+    def state():
+        if mpd_online:
+            return client.status()['state']
+
+    client = mpd.MPDClient()
+    try:
+        client.connect(mpd_host, mpd_port)
+        if mpd_passwd:
+            client.password(mpd_passwd)
+        mpd_online = True
+    except:
+        mpd_online = False
+
+    result =    { 'get_meta':   get_meta,
+                  'stop':       stop,
+                  'pause':      pause,
+                  'play':       play,
+                  'next':       next,
+                  'previous':   previous,
+                  'state':      state
+                }[query]()
+
+    return result
+
+def get_librespot_meta():
+    """ gets metadata info from librespot """
+    # Unfortunately librespot only prints out the title metadata, nor artist neither album.
+    # More info can be retrieved from the spotify web, but it is necessary to register
+    # for getting a privative and unique http request token for authentication.
+
+    player = 'Spotify'
+    artist = album = title = ''
+
+    try:
+        # Returns the current track title played by librespot.
+        # <scripts/librespot.py> handles the libresport print outs to be redirected to <~/tmp/.librespotEvents>
+        tmp = sp.check_output( 'tail -n1 /home/predic/tmp/.librespotEvents'.split() )
+        title  = tmp.decode().split('"')[-2]
+        # JSON for JavaScript on control web page, NOTICE json requires double quotes:
+    except:
+        pass
+
+    return '{ "player":"' + player + '", "artist":"' + artist + \
+           '", "album":"' + album + '", "title":"' + title + '" }'
+
+def predic_source():
+    """ retrieves the current input source """
+    source = None
+    # It is possible to fail while state file is updating :-/
+    times = 4
+    while times:
+        try:
+            source = get_predic_state()['input']
+            break
+        except:
+            times -= 1
+        time.sleep(.25)
+    return source
+
+def get_meta():
+    """ Retrieves a dictionary with the current track metadata
+        {player: xxxx, artist: xxxx, album:xxxx, title:xxxx }
+    """
+    player = artist = album = title = ''
+    source = predic_source()
+
+    if source == 'spotify':
+        return get_librespot_meta()
+
+    elif source == 'mpd':
+        return mpd_client('get_meta')
+
+    else:
+        return '{ "player":"' + player + '", "artist":"' + artist + \
+               '", "album":"' + album + '", "title":"' + title + '" }'
+
+def control(action):
+    """ controls the playback """
+    result = ''
+
+    if predic_source() == 'mpd':
+        result = mpd_client(action)
+
+    elif predic_source() == 'spotify':
+        # WORK IN PROGRESS
+        pass
+
+    elif predic_source() == 'tdt':
+        # WORK IN PROGRESS
+        pass
+
+    if result:
+        return result.encode()
+    else:
+        return ''.encode()

--- a/bin/server_aux.py
+++ b/bin/server_aux.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+
+""" A TCP server that listen for certain tasks to be executed on local:
+    - Switches on/off an amplifier
+    - Controls and gets metadata info from the player we are listen to
+    - Other tasks are still not implemented
+"""
+# This server is secured by allowing only certain orders
+# to be translated to actual local commands.
+#####################
+LISTENING_PORT = 9998
+#####################
+
+import socket
+import sys
+import time
+import subprocess as sp
+import yaml
+import players # to comunicate to the current music player
+
+def process(data):
+    """
+        Only certain received 'data' will be validated and processed,
+        then returns back some useful info to the asking client.
+    """
+
+    # First clearing the new line
+    data = data.replace('\n','')
+
+    # A custom script that switches on/off the amplifier
+    # notice: subprocess.check_output(cmd) returns bytes-like,
+    #         but if cmd fails an exception will be raised, so used with 'try'
+    if data == 'ampli on':
+        try:
+            sp.check_output( '/home/predic/bin_custom/ampli.sh on'.split() )
+            return b'done'
+        except:
+            return b'error'
+    elif data == 'ampli off':
+        try:
+            sp.check_output( '/home/predic/bin_custom/ampli.sh off'.split() )
+            return b'done'
+        except:
+            return b'error'
+
+    # Queries the current music player
+    elif data == 'player_get_meta':
+        return players.get_meta().encode()
+    elif data == 'player_state':
+        return players.control('state')
+    elif data == 'player_stop':
+        return players.control('stop')
+    elif data == 'player_pause':
+        return players.control('pause')
+    elif data == 'player_play':
+        return players.control('play')
+    elif data == 'player_next':
+        return players.control('next')
+    elif data == 'player_previous':
+        return players.control('previous')
+
+def server_socket(host, port):
+    """ Makes a socket for listening clients """
+
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    except socket.error as e:
+        print(f'(server) Error creating socket: {e}')
+        sys.exit(-1)
+    # we use opción socket.SO_REUSEADDR to avoid this error:
+    # socket.error: [Errno 98] Address already in use
+    # that can happen if we reinit this script.
+    # This is because the previous execution has left the socket in a
+    # TIME_WAIT state, and cannot be immediately reused.
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    # tcp socket
+    try:
+        s.bind((host, port))
+    except:
+        print('(server_aux) Error binding port', port)
+        s.close()
+        sys.exit(-1)
+
+    # return socket state
+    return s
+
+if __name__ == '__main__':
+
+    verbose = False
+    fsocket = server_socket('localhost', LISTENING_PORT)
+
+    for opc in sys.argv:
+        if '-v' in opc:
+            verbose = True
+
+    # main loop to proccess conections
+    backlog = 10
+    while True:
+        # listen ports
+        fsocket.listen(10)  # number of connections in queue
+        if verbose:
+            print(f'(server_aux) listening on \'localhost\':{LISTENING_PORT}')
+        # accept client connection
+        sc, addr = fsocket.accept()
+        # somo info
+        if verbose:
+            print(f'(server_aux) connected to client {addr[0]}')
+        # buffer loop to proccess received command
+        while True:
+        # reception
+            data = sc.recv(4096).decode()
+            if not data:
+                # nothing in buffer, client has disconnected too soon
+                if verbose:
+                    print('(server_aux) client disconnected. '
+                                           'Closing connection...')
+                sc.close()
+                break
+            elif data.rstrip('\r\n') == 'status':
+                # echo state to client as YAML string
+                sc.send(yaml.dump( 'status: running',
+                                   default_flow_style=False).encode() )
+                sc.send(b'OK\n')
+            elif data.rstrip('\r\n') == 'quit':
+                sc.send(b'OK\n')
+                if verbose:
+                    print('(server_aux) closing connection...')
+                sc.close()
+                break
+            elif data.rstrip('\r\n') == 'shutdown':
+                sc.send(b'OK\n')
+                if verbose:
+                    print('(server_aux) closing connection...')
+                sc.close()
+                fsocket.close()
+                sys.exit(1)
+            else:
+                # a command to run has been received in 'data':
+                if verbose:
+                    print ('>>> ' + data)
+                # process() will validate the data, and if so then executed
+                result = process(data)
+                if result:
+                    sc.send( result )
+                else:
+                    sc.send( b'ACK\n' )
+
+                if verbose:
+                    print(f'(server_aux) connected to client {addr[0]}')
+
+            # wait a bit, loop again
+            time.sleep(0.01)

--- a/bin/server_aux.py
+++ b/bin/server_aux.py
@@ -8,7 +8,7 @@
 # This server is secured by allowing only certain orders
 # to be translated to actual local commands.
 #####################
-LISTENING_PORT = 9998
+LISTENING_PORT = 9988
 #####################
 
 import socket

--- a/config/scripts
+++ b/config/scripts
@@ -2,3 +2,4 @@ mpd_load.py # Don't name this mpd.py since it could interfere with mpd module
 DVB.py
 netjack.py
 alsa_loop_load.py # Sets up alsa_loop ports in jack to be used from ALSA players
+server_aux.py # A server for tasks as switching the amplifier and getting metadata from players

--- a/scripts/server_aux.py
+++ b/scripts/server_aux.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""
+    Starts the server_aux.py for some tasks as amplifier switch on/off and players management
+    
+    use:   scripts/server_aux.py    start | stop
+"""
+
+import sys
+from subprocess import Popen
+
+def start():
+    Popen( ['server_aux.py'] ) # if this fails check your paths
+
+def stop():
+    Popen( 'pkill -KILL -f server_aux.py'.split() )
+
+if sys.argv[1:]:
+    try:
+        option = {
+            'start' : start,
+            'stop'  : stop
+            }[ sys.argv[1] ]()
+    except:
+        print('(server_aux) bad option')
+else:
+    print(__doc__)

--- a/www/index.html
+++ b/www/index.html
@@ -4,17 +4,20 @@
     <title>pre.di.c</title>
 
     <!-- responsive -->
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
+    <!-- web-app behavoir (full screen when iconize at init screen on smartphones -->
+    <!-- some Androids: -->
     <meta name="mobile-web-app-capable" content="yes">
+    <!-- iOS:  https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html -->
+    <meta name="apple-mobile-web-app-capable" content="yes">
 
     <meta charset="utf-8">
 
-    <!-- Para alcanzar las funciones javascript usadas por los eventos de esta peich-->
+    <!-- The javascript functions used when an event occurs on this page body's -->
     <script src="js/functions.js"></script>
 
-    <!-- https://www.w3schools.com/colors/colors_picker.asp -->
-    <!-- OjO no meter comentarios dentro de style -->
+    <!-- Styles, WARNING do not use comments inside this tag -->
     <style>
 
         body    { color:white;
@@ -34,6 +37,8 @@
                   font-size:1.0em;
                   width: 50% }
 
+        table#player_info { width: 100%; text-align: left; }
+
         select  { font-size:1.0em;
                   font-weight:bold;
                   color:white;
@@ -43,12 +48,12 @@
 
 </head>
 
-<!-- Inicializa la peich, incluyendo su actualización periódica -->
+<!-- initizalizes the web page, and auto updates -->
 <body onload="page_initiate()" >
 
     <div id="main">
 
-        <!--    Esquema maomeno del display:
+        <!--    page scheme:
 
             power << ON/OFF >>  INPUT: << selector >>
             level: -23.0        balance: 0.0
@@ -60,8 +65,16 @@
                    XO: << selector >>
                   DRC: << selector >>
 
-                      [-3][-1][+1][+3]
+                     [-3][-1][+1][+3]
+
+            [ <| ] [ [] ] [ || ] [ > ] [ |> ]
+
+            Artists
+            Album
+            Title
+
         -->
+        
         <div id="cabecera" align="center">
         </div>
 
@@ -69,7 +82,7 @@
 
         <div align="center">
 
-            <!--Enciende y apaga el ampli-->
+            <!-- Amplifier swith -->
             <select id="onoffSelector" onchange="ampli(this.value)">
               <option value="on" >ON </option>
               <option value="off">OFF</option>
@@ -77,7 +90,7 @@
 
             &nbsp;
 
-            <!--Selector de entradas automágico-->
+            <!-- Inputs selector, will be filled by javascript -->
             INPUT:
             <select id="inputsSelector" onchange="predic_cmd('input ' + this.value, update=false)" ></select>
 
@@ -85,8 +98,8 @@
 
         <hr>
 
-        <!--Tabla -->
-        <div style="overflow-x:auto;"> <!--esto hace que la table sea responsive-->
+        <!-- Level , Balance (table display) -->
+        <div style="overflow-x:auto;"> <!-- responsive -->
         <table style="width:100%;">
             <tr>
                 <td id="status_LEV" ></td>
@@ -97,7 +110,7 @@
 
         <hr>
 
-        <!--Botonera de tonos-->
+        <!-- Tone buttons -->
         <div align="center" style="font-size:0.75em;">
             <button type="button"                 onmousedown="predic_cmd('bass   -1 add')"  >-</button>
             <span id="bassInfo">bass</span>
@@ -110,7 +123,7 @@
 
         <hr>
 
-        <!--Botonera de mute, mono, loudness-->
+        <!-- mute, mono, loudness -->
         <div align="center">
             <button type="button" id="buttonMute" onmousedown="predic_cmd('mute toggle')"           >MUTE</button>
             <button type="button" id="buttonMono" onmousedown="predic_cmd('mono toggle')"           >MONO</button>
@@ -119,23 +132,29 @@
 
         <hr>
 
+        <!--  XO selector -->
         <div align="center">
-            <!--Selector de XO automágico-->
             <span>XO:
             <select id="xoSelector"     onchange="predic_cmd('xo ' + this.value, update=false)" ></select>
             </span>
         </div>
 
+        <!-- DRC selector -->
         <div align="center">
-            <!--Selector de DRC automágico-->
             <span>DRC:
             <select id="drcSelector"     onchange="predic_cmd('drc ' + this.value, update=false)" ></select>
+            </span>
+        </div>
+        
+        <!-- a PEQ selector will be created if ecasound is used -->
+        <div align="center">
+            <span id="span_peq">
             </span>
         </div>
 
         <hr>
 
-        <!--Botonera de volumen-->
+        <!-- Volume butttons -->
         <div align="center" >
             <button type="button" style="font-size:1.2em;" onmousedown="predic_cmd('level -3 add')" >- 3</button>
             <button type="button" style="font-size:1.2em;" onmousedown="predic_cmd('level -1 add')" >- 1</button>
@@ -145,9 +164,27 @@
 
         <hr>
 
-        <!--Botón para probar funciones JS con onclick 
+        <!-- Playing control -->
+        <div id="player_control" align="center" >
+            <button type="button" id="buttonPrevious" onmousedown="playerCtrl('previous')" >&lt;|           </button>
+            <button type="button" id="buttonStop"     onmousedown="playerCtrl('stop')"     >&nbsp;[]&nbsp;  </button>
+            <button type="button" id="buttonPause"    onmousedown="playerCtrl('pause')"    >&nbsp;||&nbsp;  </button>
+            <button type="button" id="buttonPlay"     onmousedown="playerCtrl('play')"     >&nbsp;&gt;&nbsp;</button>
+            <button type="button" id="buttonNext"     onmousedown="playerCtrl('next')"     >|&gt;           </button>
+        </div>
+
+        <!-- Playing info -->
+        <div style="overflow-x:auto;">
+            <table id="player_info" >
+                <tr><td id="artist" ></td></tr>
+                <tr><td id="album"  ></td></tr>
+                <tr><td id="title"  ></td></tr>
+            </table>
+        </div>
+
+        <!-- uncomment to test javascript functions with this button
         <div align="right">
-            <button type="button"                 onclick="update_ampli_switch()" >PBA</button>
+            <button type="button"                 onclick="playerCtrl('state')" >PBA</button>
         </div>
         -->
 

--- a/www/js/functions.js
+++ b/www/js/functions.js
@@ -1,100 +1,188 @@
 /*
- * Para debug podemos printar en la consola del navegador: console.log(miVariable);
- * ***  OJO CONVIENE NO DEJAR NINGUN console.log activo porque gasta recursos
- * ***  y la respuesta de las botoneras se verá afectada.
+ * debug trick: console.log(something);
+ * NOTICE: remember do not leaving any console.log actives
 */
 
-// Función llamada por los eventos de la peich que ordenan algún cambio a pre.di.c
+// TO REVIEW: At some http request we use sync=false, this is not recommended
+//            but this way we get the answer.
+//            Maybe it is better to use onreadystatechange as per in refresh_predic_status()
+
+
+/////////////   GLOBALS //////////////
+ecasound_is_used = check_if_ecasound();     // Boolean indicates if pre.di.c uses Ecasound
+auto_update_interval = 3000;                // Auto-update interval millisec
+
+
+// Returns boolen as per 'load_ecasound = True|False' inside 'config/config.yml'
+function check_if_ecasound() {
+    var config  = get_file('config');
+    var lines   = config.split('\n');
+    var result  = false
+    var line    = ''
+    for (i in lines) {
+        line = lines[i];
+        if ( line.trim().split(':')[0].trim() == 'load_ecasound' ){
+            if ( line.trim().split(':')[1].trim() == 'True') {
+                result = true;
+            }
+        }
+    }
+    return result
+}
+
+// Used from buttons to send commands to pre.di.c
 function predic_cmd(cmd, update=true) {
-    // Envia el comando 'cmd' a pre.di.c a través del código PHP del server:
+    // Sends the command to pre.di.c through by the server's PHP:
     // https://www.w3schools.com/js/js_ajax_http.asp
     var myREQ = new XMLHttpRequest();
     myREQ.open("GET", "php/functions.php?command=" +  cmd, true);
     myREQ.send();
 
-    // Y actualizamos el nuevo estado en la página
+    // Then update the web page
     if (update) {
-        get_predic_status();
+        refresh_predic_status();
     }
 }
 
-// Controla el ampli
+// Amplifier control
 function ampli(mode) {
     var myREQ = new XMLHttpRequest();
     myREQ.open("GET", "php/functions.php?command=ampli" + mode, async=true);
     myREQ.send();
 }
 
-// Auxiliar para el autoupdate: actualiza el switch del ampli tras consultarlo al server
-// (!) async=false NO es recomendable, pero si no no obtengo la response :-?
+// Queries the amplifier switch remote state
 function update_ampli_switch() {
     var myREQ = new XMLHttpRequest();
+    var ampliStatus = '';
     myREQ.open("GET", "php/functions.php?command=amplistatus", async=false);
     myREQ.send();
     ampliStatus = myREQ.responseText.replace('\n','')
     document.getElementById("onoffSelector").value = ampliStatus;
 }
 
-// Inicializa le peich incluyendo su auto-update
+// Controls the current player
+function playerCtrl(action) {
+    var myREQ = new XMLHttpRequest();
+    myREQ.open("GET", "php/functions.php?command=player_" + action, async=true);
+    myREQ.send();
+}
+
+// Updates the player control buttons, hightlights the corresponding button to the playback state
+function update_player_controls() {
+    var myREQ = new XMLHttpRequest();
+    var playerState = '';
+    myREQ.open("GET", "php/functions.php?command=player_state", async=false);
+    myREQ.send();
+    playerState = myREQ.responseText.replace('\n','')
+    if        ( playerState == 'stop' ) {
+        document.getElementById("buttonStop").style.background  = "rgb(185, 185, 185)";
+        document.getElementById("buttonStop").style.color       = "white";
+        document.getElementById("buttonPause").style.background = "rgb(100, 100, 100)";
+        document.getElementById("buttonPause").style.color      = "lightgray";
+        document.getElementById("buttonPlay").style.background  = "rgb(100, 100, 100)";
+        document.getElementById("buttonPlay").style.color       = "lightgray";
+    } else if ( playerState == 'pause' ){
+        document.getElementById("buttonStop").style.background  = "rgb(100, 100, 100)";
+        document.getElementById("buttonStop").style.color       = "lightgray";
+        document.getElementById("buttonPause").style.background = "rgb(185, 185, 185)";
+        document.getElementById("buttonPause").style.color      = "white";
+        document.getElementById("buttonPlay").style.background  = "rgb(100, 100, 100)";
+        document.getElementById("buttonPlay").style.color       = "lightgray";
+    } else if ( playerState == 'play' ) {
+        document.getElementById("buttonStop").style.background  = "rgb(100, 100, 100)";
+        document.getElementById("buttonStop").style.color       = "lightgray";
+        document.getElementById("buttonPause").style.background = "rgb(100, 100, 100)";
+        document.getElementById("buttonPause").style.color      = "lightgray";
+        document.getElementById("buttonPlay").style.background  = "rgb(185, 185, 185)";
+        document.getElementById("buttonPlay").style.color       = "white";
+    }
+}
+
+// Shows the playing info metadata
+function update_player_info() {
+    var myREQ = new XMLHttpRequest();
+    var tmp = '';
+    myREQ.open("GET", "php/functions.php?command=player_get_meta", async=false);
+    myREQ.send();
+    tmp = myREQ.responseText.replace('\n','');
+    dicci = JSON.parse( tmp );
+    var player = dicci['player'];
+    var artist = dicci['artist'];
+    var album  = dicci['album'];
+    var title  = dicci['title'];
+    // 'player' info not anymore needed because equals to 'input' value
+    // document.getElementById("player").innerText = player + ':';
+    document.getElementById("artist").innerText = artist;
+    document.getElementById("album").innerText = album;
+    document.getElementById("title").innerText = title;
+}
+
+// Initializes the web page, then starts the auto-update
 function page_initiate() {
 
-    // Completamos los selectore de inputs, XO y DRC
+    // Filling the selectors: inputs, XO, DRC and PEQ
     fills_inputs_selector()
     fills_xo_selector()
     fills_drc_selector()
+    if ( ecasound_is_used == true){
+        insert_peq_selector();
+        fills_peq_selector();  
+    }
 
-    // Cabecera de la peich
+    // Web header shows the loudspeaker name
     document.getElementById("cabecera").innerText = ':: pre.di.c :: ' + get_loudspeaker() + ' ::';
 
-    // Inicializamos la peich con el estado de pre.di.c
-    get_predic_status();
-    // Esperamos 1 s y  programamos el auto-update como tal, cada 3 s:
-    // (OjO la llamada a la función en el setInterval va SIN paréntesis)
-    setTimeout( setInterval( get_predic_status, 3000 ), 1000);
+    // Queries the pre.di.c status and updates the page
+    refresh_predic_status();
+
+    // Waits 1 sec, then schedules the auto-update itself:
+    // Notice: the function call inside setInterval uses NO brackets)
+    setTimeout( setInterval( refresh_predic_status, auto_update_interval ), 1000);
 }
 
-// Obtiene el estado de pre.di.c hablando con el PHP del server
-function get_predic_status() {
+// Gets the pre.di.c status and updates the page
+function refresh_predic_status() {
     // https://www.w3schools.com/js/js_ajax_http.asp
 
-    // Prepara una instancia HttpRequest
     var myREQ = new XMLHttpRequest();
 
-    // Dispara una acción cuando se haya completado el HttpRequest,
-    // nosotros actualizaremos la peich con la respuesta del server.
+    // Will trigger an action when HttpRequest has completed: page_update
     myREQ.onreadystatechange = function() {
         if (this.readyState == 4 && this.status == 200) {
             page_update(this.responseText);
         }
     };
 
-    // Ejecuta la transacción HttpRequest
+    // the http request:
     myREQ.open(method="GET", url="php/functions.php?command=status", async=true);
     myREQ.send();
 }
 
-// Vuelca el estado de pre.dic.c en la peich
+// Dumps pre.di.c status into the web page
 function page_update(status) {
 
-    // Tabla de LEVEL y BALANCE
+    // LEVEL y BALANCE
     document.getElementById("status_LEV").innerHTML = 'LEVEL: '   + status_decode(status, 'level');
-    document.getElementById("status_BAL").innerHTML = 'BALANCE: ' + status_decode(status, 'balance');
+    document.getElementById("status_BAL").innerHTML = 'balance: ' + status_decode(status, 'balance');
 
-    // Texto que acompaña a los botones de Tonos
+    // Tone buttons
     document.getElementById("bassInfo").innerText   = 'BASS: '    + status_decode(status, 'bass');
-    document.getElementById("trebleInfo").innerText = 'TREBLE: '  + status_decode(status, 'treble');
+    document.getElementById("trebleInfo").innerText = 'TREB: '    + status_decode(status, 'treble');
 
-    // Elemento seleccionado en los selectores de INPUTS, XO y DRC
+    // The selected item on INPUTS, XO, DRC and PEQ
     document.getElementById("inputsSelector").value =               status_decode(status, 'input');
     document.getElementById("xoSelector").value     =               status_decode(status, 'XO_set');
     document.getElementById("drcSelector").value    =               status_decode(status, 'DRC_set');
-
-    // Rótulo de los botones MUTE, MONO, LOUDNESS en lowercase si están desactivados
+    if ( ecasound_is_used == true){
+        document.getElementById("peqSelector").value    =           status_decode(status, 'PEQ_set');
+    }
+    // MUTE, MONO, LOUDNESS buttons text lower case if deactivated
     document.getElementById("buttonMute").innerHTML = OnOff( 'mute', status_decode(status, 'muted') );
     document.getElementById("buttonMono").innerHTML = OnOff( 'mono', status_decode(status, 'mono') );
     document.getElementById("buttonLoud").innerHTML = OnOff( 'loud', status_decode(status, 'loudness_track') );
 
-    // Destacamos los botones que están activados
+    // Highlights activated buttons
     if ( status_decode(status, 'muted') == 'true' ) {
         document.getElementById("buttonMute").style.background = "rgb(185, 185, 185)";
         document.getElementById("buttonMute").style.color = "white";
@@ -117,17 +205,21 @@ function page_update(status) {
         document.getElementById("buttonLoud").style.color = "lightgray";
     }
 
-    // Actualizamos el switch del ampli
+    // Updates the amplifier switch
     update_ampli_switch()
+    
+    // Updates metadata player info
+    update_player_info()
+
+    // Highlights player controls when activated
+    update_player_controls()
 
 }
 
-// Auxiliar ortopédico para pedir ciertos archivos al servidor PHP
-// (!) async=false NO es recomendable, pero esto sólo se ejecuta al inicio
-//     y de esta forma llega lo que tiene que llegar ;-)
+// Getting files from server
 function get_file(fid) {
     var phpCmd   = "";
-    var response = "todavia_sin_respuesta";
+    var response = "still_no_answer";
     if      ( fid == 'inputs' ) {
         phpCmd = 'read_inputs_file';
     }
@@ -146,10 +238,10 @@ function get_file(fid) {
     return (myREQ.responseText);
 }
 
-// Averigua el valor de una de las propiedades del chorizo status de pre.di.c
+// Decodes the value from a pre.di.c parameter inside the pre.di.c status stream
 function status_decode(status, prop) {
     var result = "";
-    arr = status.split("\n"); // Las parejas 'propiedad:valor' vienen separadas por saltos de línea
+    arr = status.split("\n"); // the tuples 'parameter:value' comes separated by line breaks
     for ( i in arr ) {
         if ( prop == arr[i].split(":")[0] ) {
             result = arr[i].split(":")[1]
@@ -158,7 +250,7 @@ function status_decode(status, prop) {
     return String(result).trim();
 }
 
-// Auxiliar para rotular propiedades como por ejemplo muted:true/false ==> 'MUTE' / 'mute'
+// To upper-lower case button labels, e.g. muted:true/false ==> 'MUTE' / 'mute'
 function OnOff(prop, truefalse) {
     var label = '';
     label = prop.toLowerCase()
@@ -166,12 +258,11 @@ function OnOff(prop, truefalse) {
     return label;
 }
 
-// Prepara el selector de entradas
+// Fills out the inputs selector
 function fills_inputs_selector() {
     var inputs = [];
 
-    // Leemos el contenido de "config/inputs.yml"
-    // y a falta de un decodificador YAML, lo analizamos a pedales
+    // Reads "config/inputs.yml" and custom YAML decoding
     var arr = get_file('inputs').split('\n')
     for ( i in arr) {
         if ( (arr[i].substr(-1)==":") && (arr[i].substr(0,1)!=" ") ) {
@@ -179,7 +270,7 @@ function fills_inputs_selector() {
         }
     }
 
-    // Ahora rellenamos el selector de entradas de la peich con las encontradas
+    // Filling the options in the inputs selector
     // https://www.w3schools.com/jsref/met_select_add.asp
     var x = document.getElementById("inputsSelector");
     for ( i in inputs) {
@@ -187,14 +278,15 @@ function fills_inputs_selector() {
         option.text = inputs[i];
         x.add(option);
     }    
-    // Y añadimos la entrada 'none' prevista en server_process que desconectará todo:
+
+    // And adds the input 'none' as intended into server_process that will disconnet all inputs
     var option = document.createElement("option");
     option.text = 'none';
     x.add(option);
     
 }
 
-// Prepara el selector de XO
+// XO selector
 function fills_xo_selector() {
     var xo_sets = get_speaker_prop_sets('XO');
     var x = document.getElementById("xoSelector");
@@ -205,7 +297,7 @@ function fills_xo_selector() {
     }
 }
 
-// Prepara el selector de DRC
+// DRC selector
 function fills_drc_selector() {
     var drc_sets = get_speaker_prop_sets('DRC');
     var x = document.getElementById("drcSelector");
@@ -216,8 +308,34 @@ function fills_drc_selector() {
     }
 }
 
-// Obtiene el nombre del altavoz
-// (nota: ahora php ya lo conoce se lo podríamos preguntar pero esto lo hice antes)
+// Inserts the PEQ selector if Ecasound is used
+function insert_peq_selector(){
+
+    // defines the selector
+    var nuevoSelector = document.createElement("select");
+    nuevoSelector.setAttribute("id", "peqSelector");
+    nuevoSelector.setAttribute("onchange", "predic_cmd('peq ' + this.value, update=false)" );
+
+    // Appends it
+    var element = document.getElementById("span_peq");
+    // And label it with 'PEQ:'
+    element.innerHTML = 'PEQ:';
+    element.appendChild(nuevoSelector);
+}
+
+// PEQ selector
+function fills_peq_selector() {
+    var peq_sets = get_speaker_prop('PEQ');
+    var x = document.getElementById("peqSelector");
+    for ( i in peq_sets ) {
+        var option = document.createElement("option");
+        option.text = peq_sets[i];
+        x.add(option);
+    }
+}
+
+// Gets the current loudspeaker
+// (recently the php server knows it, but this was done before)
 function get_loudspeaker() {
     var result = '';
     var config = get_file('config');
@@ -231,12 +349,12 @@ function get_loudspeaker() {
     return result;
 }
 
-// Obtiene la lista con los 'sets:' declarados en una propiedad del altavoz, por ej 'XO:' o 'DRC:'
+// Gets the sets defined into XO or DRC inside speaker.yml
 function get_speaker_prop_sets(prop) {
     var prop_sets = [];
     var yaml = get_file('speaker');
 
-    // yaml es un YAML, lo suyo sería usar un parser pero vamos a hacerlo a manubrio:
+    // custom YAML decoder
     var arr = yaml.split("\n");
     var dentroDeProp = false, dentroDeSets = false, indentOfSets = 0;
     for (i in arr) {
@@ -263,8 +381,35 @@ function get_speaker_prop_sets(prop) {
     return (prop_sets);
 }
 
-// Auxiliar para averiguar el nivel de indentación de una linea de código,
-// por ejemplo de una linea de un archivo YAML.
+// Gets the options from some speaker property, e.g. from PEQ.
+function get_speaker_prop(prop) {
+    var opcs = [];
+    var yaml = get_file('speaker');
+
+    // custom YAML decoder
+    var arr = yaml.split("\n");
+    var dentroDeProp = false;
+    for (i in arr) {
+        linea = arr[i];
+        if ( linea.slice(0, (prop.length)+1 ) == prop+':') { dentroDeProp = true; };
+        if ( dentroDeProp ) {
+
+            tmp = linea.replace( prop + ':', '' );
+            tmp = tmp.replace('{', '').replace('}', '');
+            fields = tmp.split(',');
+            for (i in fields) {
+                f = fields[i];
+                opc = f.split(':')[0].trim()
+                opcs.push( opc );
+            }
+
+            if ( indentLevel(linea) <= 1 ){ break; }
+        }
+    }
+    return (opcs);
+}
+
+// Aux function that retrieves the indentation level of some code line, useful for YAML decoding.
 function indentLevel(linea) {
     var level = 0;
     for ( i in linea ) {

--- a/www/php/functions.php
+++ b/www/php/functions.php
@@ -1,26 +1,10 @@
 <?php
 
-    /*
-     * Para depurar https://www.ibm.com/developerworks/library/os-debug/index.html
-     * En nuestro caso también podemos hacer aquí echo $miVariable, que será recibida por
-     * la función JS que haya hecho la http request en el cliente y printarlo allí en
-     * la consola del navegador con console.log(respuesta).
+    /*  Hidden server side php code.
+     *  PHP will response to the client via the standard php output (echo xxx, readfile(xx), etcetera)
      */
 
-    /* Este código PHP reside localmente en el server y no es visible desde el navegador.
-     * Este PHP sera cargado por Apache (si tiene enabled el php_mod),
-     * entonces se ESCUCHARAN HTTP_REQUEST como por ejemplo:
-     *     "GET", "php/functions.php?command=level -15"
-     * que son generadas por el JS del cliente.
-     *
-     * Las RESPUESTAS se devolverán mediante la salida estandar de este código,
-     * bien mediante 'echo xxxx' o bien mediante algunas funciones que vuelcan su resultado
-     * directamente a la salida estandar, como por ejemplo 'readfile()' -ver abajo-
-     */
-
-    // Este script debe conocer el nombre del altavoz running para acceder al path
-    // adecuado a la hora de proporcionar un archivo speaker.yml al cliente
-    // (he preferido que el código js del cliente no muestre paths del servidor)
+    // Retrieves the running loudspeaker on pre.di.c
     function get_loudspeaker() {
         $tmp = "";
         $cfile = fopen("/home/predic/config/config.yml", "r")
@@ -38,7 +22,7 @@
         return $tmp;
     }
 
-    // Dialoga con el server TCP/IP de pre.di.c
+    // Communicates to the pre.di.c TCP/IP server
     function predic_socket ($cmd) {
         $service_port = 9999;
         $address = "localhost";
@@ -62,8 +46,8 @@
         return $out;
     }
 
-    // Dialoga con el server TCP/IP 'server_local.py' que hace lo que se le pida =|:0
-    function local_socket ($cmd) {
+    // Communicates to the auxiliary tasks pre.di.c's TCP/IP server
+    function aux_socket ($cmd) {
         $service_port = 9988;
         $address = "localhost";
         /* Crear un socket TCP/IP */
@@ -86,26 +70,26 @@
         return $out;
     }
 
-    ///////////////////   MAIN: ///////////////////////
-    // Procesa el COMMAND recibido en la HTTPREQUEST
-    // y devuelve resultados mediante 'echo xxxxx'
-    ///////////////////////////////////////////////////
+    ///////////////////////////   MAIN: ///////////////////////////////
+    // listen to http request then returns results via standard output
+    ///////////////////////////////////////////////////////////////////
 
     /* http://php.net/manual/en/reserved.variables.request.php
-    * PHP server side recibe arrays asociativas, o sea diccionarios, mediante los métodos
-    * GET o PUT de las HTTPREQUEST originadas por un código del cliente, en nuestro caso
-    * es el JS cargado en el navegador que forma parte de la peich.
-    * La array es lo que el cliente pone detrás del interrogante, por ejemplo:
+    * PHP server side receives associative arrays, i.e. dictionaries, through by the 
+    * GET o PUT methods from the client side HTTPREQUEST (usually javascript).
+    * The array is what appears after 'php/functions.php?.......', example:
     *          "GET", "php/functions.php?command=level -15"
-    * Como es un array, debemos seleccionar la clave que nos interesa:
+    * Here the key 'command' has the value 'level -15'
     */
 
+    // lets read the key 'command'
     $command = $_REQUEST["command"];
 
-    // Comandos especiale;s:
+    //// SPECIAL commands:
+
+    // Reading config files
     if ( $command == "read_inputs_file" ) {
-        // OjO readfile proporciona un 'echo' del contenido del archivo, a saco.
-        // Es decir: vuelca el contenido del archivo a la salida estandar de php.
+        // notice: readfile() does an 'echo', i.e. it returns the contents to the standard php output
         readfile("/home/predic/config/inputs.yml");
     }
     elseif ( $command == "read_config_file" ) {
@@ -115,22 +99,28 @@
         $fpath = "/home/predic/loudspeakers/".get_loudspeaker()."/speaker.yml";
         readfile($fpath);
     }
+
+    // Amplifier switching
     elseif ( $command == "amplion" ) {
-        // local_server.py escribirá el estado del amplificador en ~/.ampliwww
-        // para posterior consulta en los updates de la peich
-        local_socket('ampli on');
+        // The remote script will store the amplifier state into
+        // ~/.ampli so that the web can update it.
+        aux_socket('ampli on');
     }
     elseif ( $command == "amplioff" ) {
-        local_socket('ampli off');
+        aux_socket('ampli off');
     }
     elseif ( $command == "amplistatus" ) {
-        readfile("/home/predic/.ampli"); // php no puede acceder a /tmp por razones de seguridad
+        readfile("/home/predic/.ampli"); // php cannot acces inside /tmp for securety reasons.
     }
 
-    // Comandos estandar para pre.di.c (devolvemos el resultado con el echo)
+    // Player related commands
+    elseif ( substr( $command, 0, 7 ) === "player_" ) {
+        echo aux_socket($command);
+    }
+
+    //// Any else will be an STANDARD pre.di.c command, then forwarded to pre.di.c's server
     else {
         echo predic_socket($command);
     }
 
 ?>
-


### PR DESCRIPTION
New features for the web control page:

- controls and gets metadata from the current player source
- controls the peq if activated
- controls an amplifier on/off switch (or whatever relay power plug)

News files are:

- `server_aux.py`  an auxiliary server that listen for some special tasks (players comunication, power relay, etc). 

- `players.py` is a module to interface to the current player in order to control the playback and getting metadata info.