### PR TITLE
adds 'headroom' info to state file

### DIFF
--- a/bin/server_process.py
+++ b/bin/server_process.py
@@ -559,6 +559,7 @@ def proccess_commands(full_command, state=gc.state, curves=curves):
             commit_gain()
             change_eq()
             state['level'] = pd.calc_level(gain, state['input'])
+            state['headroom'] = float( np.round(headroom, 2) )
         # if not enough headroom tries lowering gain
         else:
             change_gain(gain + headroom)


### PR DESCRIPTION
Although clients can calculate it, I propose to include headroom information to be easily readable. For example an external sound volume manager can inject some advisory beep when the user approach to some headroom threshold, as kind of 'cuidadin'. 

https://github.com/Rsantct/pre.di.c/blob/master/pre.di.c/clients/bin/mouse_volume_daemon.py
https://github.com/Rsantct/pre.di.c/blob/master/pre.di.c/scripts/mouse_volume.py

